### PR TITLE
Не понятно, почему парс считается удачным только в том случае, если результат не является null-ом.

### DIFF
--- a/Excel.TemplateEngine/ObjectPrinting/TableParser/TableParser.cs
+++ b/Excel.TemplateEngine/ObjectPrinting/TableParser/TableParser.cs
@@ -17,16 +17,10 @@ namespace SkbKontur.Excel.TemplateEngine.ObjectPrinting.TableParser
             this.navigator = navigator;
         }
 
-        /// <summary>
-        ///     Be careful! Result can be both null and "" when cell is empty (seems like it depends on the way of file creation)
-        /// </summary>
-        /// <param name="result"></param>
-        /// <returns></returns>
         public bool TryParseAtomicValue(out string result)
         {
-            var cellValue = target.GetCell(CurrentState.Cursor)?.StringValue;
-            result = cellValue;
-            return result != null;
+            result = target.GetCell(CurrentState.Cursor)?.StringValue;
+            return true;
         }
 
         public bool TryParseAtomicValue(out int result)


### PR DESCRIPTION
Не понятно, почему результат парса может быть, как null-ом, так и пустой строкой, но удачным парс считается только в том случае, если результат не является null-ом.

Причина изменения: в MEDI сделали импорт Excel, пользователь загрузил файл, в котором не заполнил опцианальный параметр, импорт не прошёл, поскольку ячейка содержала не пустую строку, а null.