### PR TITLE
Добавление дочерних элементов листа в корректном порядке

### DIFF
--- a/Excel.TemplateEngine.Tests/ObjectPrintingTests/ManualPrintingTests.cs
+++ b/Excel.TemplateEngine.Tests/ObjectPrintingTests/ManualPrintingTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using NUnit.Framework;
 
 using SkbKontur.Excel.TemplateEngine.FileGenerating;
+using SkbKontur.Excel.TemplateEngine.FileGenerating.DataTypes;
 using SkbKontur.Excel.TemplateEngine.FileGenerating.Primitives;
 using SkbKontur.Excel.TemplateEngine.ObjectPrinting.ExcelDocumentPrimitives.Implementations;
 using SkbKontur.Excel.TemplateEngine.ObjectPrinting.NavigationPrimitives.Implementations;
@@ -26,15 +27,7 @@ namespace SkbKontur.Excel.TemplateEngine.Tests.ObjectPrintingTests
             {
                 targetDocument.CopyVbaInfoFrom(templateDocument);
 
-                foreach (var index in Enumerable.Range(1, templateDocument.GetWorksheetCount() - 1))
-                {
-                    var worksheet = templateDocument.GetWorksheet(index);
-                    var name = templateDocument.GetWorksheetName(index);
-                    var innerTemplateEngine = new SkbKontur.Excel.TemplateEngine.TemplateEngine(new ExcelTable(worksheet), logger);
-                    var targetWorksheet = targetDocument.AddWorksheet(name);
-                    var innerTableBuilder = new TableBuilder(new ExcelTable(targetWorksheet), new TableNavigator(new CellPosition("A1"), logger));
-                    innerTemplateEngine.Render(innerTableBuilder, new {});
-                }
+                CopySecondaryWorksheets(templateDocument, targetDocument);
 
                 var template = new ExcelTable(templateDocument.GetWorksheet(0));
                 var templateEngine = new SkbKontur.Excel.TemplateEngine.TemplateEngine(template, logger);
@@ -247,6 +240,7 @@ namespace SkbKontur.Excel.TemplateEngine.Tests.ObjectPrintingTests
 
                 var target = new ExcelTable(targetDocument.GetWorksheet(0));
                 var tableNavigator = new TableNavigator(new CellPosition("A1"), logger);
+                targetDocument.GetWorksheet(0).SetPrinterSettings(printerSettings);
                 var tableBuilder = new TableBuilder(target, tableNavigator, new Style(template.GetCell(new CellPosition("A1"))));
                 templateEngine.Render(tableBuilder, new {});
 
@@ -276,5 +270,19 @@ namespace SkbKontur.Excel.TemplateEngine.Tests.ObjectPrintingTests
         }
 
         private readonly ConsoleLog logger = new ConsoleLog();
+
+        private static readonly ExcelPrinterSettings printerSettings = new ExcelPrinterSettings
+            {
+                PrintingOrientation = ExcelPrintingOrientation.Landscape,
+                PageMargins = new ExcelPageMargins
+                    {
+                        Left = 0.25,
+                        Right = 0.25,
+                        Top = 0.75,
+                        Bottom = 0.75,
+                        Header = 0.3,
+                        Footer = 0.3
+                    }
+            };
     }
 }

--- a/Excel.TemplateEngine/Excel.TemplateEngine.csproj
+++ b/Excel.TemplateEngine/Excel.TemplateEngine.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="morelinq" Version="3.2.0" />
     <PackageReference Include="C5" Version="2.5.3" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.9.1" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.11.3" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Vostok.Logging.Abstractions" Version="1.0.1" />
   </ItemGroup>

--- a/Excel.TemplateEngine/FileGenerating/Helpers/OpenXmlElementHelper.cs
+++ b/Excel.TemplateEngine/FileGenerating/Helpers/OpenXmlElementHelper.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Linq;
+
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace SkbKontur.Excel.TemplateEngine.FileGenerating.Helpers
+{
+    public static class OpenXmlElementHelper
+    {
+        // todo (a.dobrynin, 05.08.2020): replace this method with targetWorksheet.AddChild(child) when DocumentFormat.OpenXml 2.12.0 is released
+        // https://github.com/OfficeDev/Open-XML-SDK/pull/774
+        /// <summary>
+        ///     Adds node in the correct location according to the schema
+        ///     http://msdn.microsoft.com/en-us/library/office/cc880096(v=office.15).aspx
+        ///     https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.worksheet?view=openxml-2.8.1#definition
+        ///     https://github.com/OfficeDev/Open-XML-SDK/blob/058ec42001ca97850fd82cc16e3b234c155a6e7e/src/DocumentFormat.OpenXml/GeneratedCode/schemas_microsoft_com_office_excel_2006_main.g.cs#L90
+        /// </summary>
+        public static T AddChildToCorrectLocation<T>(this OpenXmlCompositeElement parent, T child) where T : OpenXmlElement
+        {
+            if (!(parent is Worksheet))
+                throw new InvalidOperationException("Schema-oriented insertion is supported only for Worksheets");
+
+            var precedingElementTypes = openXmlWorksheetNodesOrder.TakeWhile(x => x != typeof(T));
+            var closestPrecedingSibling = precedingElementTypes.Reverse()
+                                                               .Select(precedingElementType => parent.Elements().LastOrDefault(x => x.GetType() == precedingElementType))
+                                                               .FirstOrDefault(existingElement => existingElement != null);
+
+            return closestPrecedingSibling != null
+                       ? parent.InsertAfter(child, closestPrecedingSibling)
+                       : parent.InsertAt(child, 0);
+        }
+
+        private static readonly Type[] openXmlWorksheetNodesOrder =
+            {
+                typeof(SheetProperties),
+                typeof(SheetDimension),
+                typeof(SheetViews),
+                typeof(SheetFormatProperties),
+                typeof(Columns),
+                typeof(SheetData),
+                typeof(SheetCalculationProperties),
+                typeof(SheetProtection),
+                typeof(ProtectedRanges),
+                typeof(Scenarios),
+                typeof(AutoFilter),
+                typeof(SortState),
+                typeof(DataConsolidate),
+                typeof(CustomSheetViews),
+                typeof(MergeCells),
+                typeof(PhoneticProperties),
+                typeof(ConditionalFormatting),
+                typeof(DataValidations),
+                typeof(Hyperlinks),
+                typeof(PrintOptions),
+                typeof(PageMargins),
+                typeof(PageSetup),
+                typeof(HeaderFooter),
+                typeof(RowBreaks),
+                typeof(ColumnBreaks),
+                typeof(CustomProperties),
+                typeof(CellWatches),
+                typeof(IgnoredErrors),
+                typeof(Drawing),
+                typeof(LegacyDrawing),
+                typeof(LegacyDrawingHeaderFooter),
+                typeof(DrawingHeaderFooter),
+                typeof(Picture),
+                typeof(OleObjects),
+                typeof(Controls),
+                typeof(WebPublishItems),
+                typeof(TableParts),
+                typeof(WorksheetExtensionList),
+            };
+    }
+}


### PR DESCRIPTION
Эксель требует упорядоченности дочерних элементов, иначе эксель крашится. 
Тут вставляю по захардкоженному у нас порядку.

В DocumentFormat.OpenXml скоро завезут метод, который будет это делать сам, по схеме (https://github.com/OfficeDev/Open-XML-SDK/pull/774)
Надо будет обновиться и выпилить мой костыль