### PR TITLE
Fix concurrent bug

### DIFF
--- a/Excel.TemplateEngine/Excel.TemplateEngine.csproj
+++ b/Excel.TemplateEngine/Excel.TemplateEngine.csproj
@@ -12,12 +12,8 @@
     <PackageReference Include="C5" Version="2.5.3" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.19.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
-    <PackageReference Include="Vostok.Logging.Abstractions" Version="1.0.30" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='net471'">
-    <!-- we need to reference System.IO.Packaging directly since net46-targeted DocumentFormat.OpenXml package does not depend on it anymore (see https://github.com/OfficeDev/Open-XML-SDK/pull/783) -->
     <PackageReference Include="System.IO.Packaging" Version="6.0.0" />
+    <PackageReference Include="Vostok.Logging.Abstractions" Version="1.0.30" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Trying to fix bug, described [here](https://social.msdn.microsoft.com/Forums/en-US/38799acc-f135-4051-8c10-98956abf4a8a/systemiopackagingpackagepackageproperties-randomly-throws-an-argumentoutofrangeexception?forum=windowsxps)

When we creating document first time, it is possible to catch a race condition

To reproduce, run this code around 50 times:

```
var tasks = Enumerable
            .Range(0, 10)
            .Select(x => Task.Run(() => { ExcelDocumentFactory.CreateFromTemplate(templateBytes, new ConsoleLog()); }))
            .ToArray();

foreach (var task in tasks)
{
    task.GetAwaiter().GetResult();
}
```

Example of `.ps` script for running code many times
```
for($i=1; $i -le 50; $i++){
    dotnet test --no-build --no-restore --framework net6.0 --filter "FullyQualifiedName=<NameOfTestCode>"
}
```